### PR TITLE
Fix some possible inconsistencies in the example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ docker-run: #docker-build
 		-e IVCAP_NODE_ID=n0 \
 		-v ${PROJECT_DIR}:/data/in \
 		-v ${PROJECT_DIR}/DATA/run:/data/out \
-		-v ${PROJECT_DIR}/DATA/run:/data/cache \
+		-v ${PROJECT_DIR}/DATA/run:/app/cache \
 		--user ${DOCKER_USER} \
 		${DOCKER_NAME} \
 		--msg "$(shell date "+%d/%m-%H:%M:%S")" \

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ To build the docker container, publish it to the repository and register the ser
 IVCAP deploymewnt.
 
 ```
+make docker-build
+
 make docker-publish
 ```
 

--- a/hello_world_service.py
+++ b/hello_world_service.py
@@ -63,7 +63,7 @@ def service(args: ServiceArgs, svc_logger: logging):
     canvas.text(center, args.msg, font=font, anchor='mm', fill=(255, 130, 0))
 
     meta = create_metadata('urn:example:schema:simple-python-service', **args._asdict())
-    deliver_data("image.png", lambda fd: img.save(fd, format="png"), SupportedMimeTypes.JPEG, metadata=meta)
+    publish_artifact("cache/image.png", lambda fd: img.save(fd, format="png"), SupportedMimeTypes.JPEG, metadata=meta)
 
 #####
 # An example of how to register an artifact saver for a non-supported Mime-Type


### PR DESCRIPTION
Some issues I noticed when running the example. Maybe these were due to my misunderstanding of IVCAP. These are my fix that got it run:
- add make docker-build before docker-run in readme.
- change target directory from data/cache to app/cache in makefile docker-run.
- use cache/image.png to store generated artifact.