### PR TITLE
hardening deployment step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ GIT_TAG := $(shell git describe --abbrev=0 --tags ${TAG_COMMIT} 2>/dev/null || t
 VERSION="${GIT_TAG}|${GIT_COMMIT}|$(shell date -Iminutes)"
 
 DOCKER_USER="$(shell id -u):$(shell id -g)"
-DOCKER_DOMAIN=$(shell echo ${PROVIDER_NAME} | sed -E 's/[-:]/_/g')
 DOCKER_NAME=$(shell echo ${SERVICE_NAME} | sed -E 's/-/_/g')
 DOCKER_VERSION=${GIT_COMMIT}
 DOCKER_TAG=${DOCKER_NAME}:${DOCKER_VERSION}

--- a/Makefile
+++ b/Makefile
@@ -97,7 +97,7 @@ docker-build-nuitka:
 		${PROJECT_DIR} ${DOCKER_BILD_ARGS}
 	@echo "\nFinished building docker image ${DOCKER_NAME}\n"
 
-SERVICE_IMG := ${DOCKER_DEPLOY}
+SERVICE_IMG := ""
 PUSH_FROM := ""
 
 docker-publish:
@@ -123,13 +123,7 @@ docker-publish:
 	fi
 
 docker-publish-common:
-	@$(eval log:=$(shell ivcap package push --force ${PUSH_FROM}${DOCKER_TAG} | tee /dev/tty))
-	@$(eval registry := $(shell echo ${DOCKER_REGISTRY} | cut -d'/' -f1))
-	@$(eval SERVICE_IMG := $(shell echo ${log} | sed -E "s/.*(${registry}.*) pushed.*/\1/"))
-	@if [ ${SERVICE_IMG} == "" ] || [ ${SERVICE_IMG} == ${DOCKER_DEPLOY} ]; then \
-		echo "service package push failed"; \
-		exit 1; \
-	fi
+	ivcap package push --force ${PUSH_FROM}${DOCKER_TAG}
 
 service-description:
 	$(eval account_id=$(shell ivcap context get account-id))
@@ -156,7 +150,7 @@ service-register: docker-publish
 		IVCAP_ACCOUNT_ID=${account_id} \
 		IVCAP_CONTAINER=${image} \
 	python ${SERVICE_FILE} --ivcap:print-service-description \
-	| ivcap service update --create ${SERVICE_ID} --format yaml -f - --timeout 600
+	| ivcap service update --create ${service_id} --format yaml -f - --timeout 600
 
 clean:
 	rm -rf ${PROJECT_DIR}/$(shell echo ${SERVICE_FILE} | cut -d. -f1 ).dist


### PR DESCRIPTION
The service-register target in Makefile did not indicate any problems if the respective docker image was not properly uploaded. Also the service-id wasn't really calculated as the code would suggest.

However, `docker-deploy` fails for me, could be an authorisation issue

```
% make docker-publish
Publishing docker image 'hello_world_python:6760a50'
docker tag hello_world_python:latest hello_world_python:6760a50
sleep 1
ImageSize is 253806517
 Pushing hello_world_python:6760a50 from local, may take multiple minutes depending on the size of the image ...
 5a08d20d3f    10.00MB    out of   33.40MB uploading...Error: failed to push layer 5a08d20d3f, 33.40MB, error: {"name":"fault","id":"wFKab9qp","message":"failed to upload docker image: failed to check layer exists: HEAD https://australia-southeast1-docker.pkg.dev/v2/sigma8-prod-21f8/sdcap-services/45a06508-5c3a-4678-8e6d-e6399bf27538/hello_world_python/blobs/sha256:5a08d20d3f0e2a85342ef841a32f3bc69b68c8d8a1fe23cf91c7ce95c594acff: unexpected status code 403 Forbidden (HEAD responses have no body, use GET for details)","temporary":false,"timeout":false,"fault":true}
```